### PR TITLE
Debug vercel botid client-side challenge issue

### DIFF
--- a/packages/react/src/use-assistant.ts
+++ b/packages/react/src/use-assistant.ts
@@ -150,7 +150,7 @@ export function useAssistant({
       abortControllerRef.current = abortController;
 
       const actualFetch = fetch ?? getOriginalFetch();
-      const response = await actualFetch(api, {
+      const requestInit: RequestInit = {
         method: 'POST',
         credentials,
         signal: abortController.signal,
@@ -164,7 +164,15 @@ export function useAssistant({
           // optional request data:
           data: requestOptions?.data,
         }),
-      });
+      };
+
+      // initial request
+      let response = await actualFetch(api, requestInit);
+
+      // If unauthorized, retry once to support BotID cookie challenge flows
+      if (response.status === 401) {
+        response = await actualFetch(api, requestInit);
+      }
 
       if (!response.ok) {
         throw new Error(

--- a/packages/ui-utils/src/call-chat-api.ts
+++ b/packages/ui-utils/src/call-chat-api.ts
@@ -40,19 +40,37 @@ export async function callChatApi({
   fetch: ReturnType<typeof getOriginalFetch> | undefined;
   lastMessage: UIMessage | undefined;
 }) {
-  const response = await fetch(api, {
-    method: 'POST',
-    body: JSON.stringify(body),
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-    },
-    signal: abortController?.()?.signal,
-    credentials,
-  }).catch(err => {
+  const doRequest = async (): Promise<Response> =>
+    fetch(api, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers,
+      },
+      signal: abortController?.()?.signal,
+      credentials,
+    });
+
+  // initial request
+  let response: Response;
+  try {
+    response = await doRequest();
+  } catch (err) {
     restoreMessagesOnFailure();
     throw err;
-  });
+  }
+
+  // If unauthorized, retry once. This supports BotID-style first-call challenge flows
+  // where cookies/headers may be set on the first response and included on retry.
+  if (response.status === 401) {
+    try {
+      response = await doRequest();
+    } catch (err) {
+      restoreMessagesOnFailure();
+      throw err;
+    }
+  }
 
   if (onResponse) {
     try {

--- a/packages/ui-utils/src/call-completion-api.ts
+++ b/packages/ui-utils/src/call-completion-api.ts
@@ -48,7 +48,7 @@ export async function callCompletionApi({
     // Empty the completion immediately.
     setCompletion('');
 
-    const response = await fetch(api, {
+    const requestInit: RequestInit = {
       method: 'POST',
       body: JSON.stringify({
         prompt,
@@ -60,9 +60,18 @@ export async function callCompletionApi({
         ...headers,
       },
       signal: abortController.signal,
-    }).catch(err => {
+    };
+
+    let response = await fetch(api, requestInit).catch(err => {
       throw err;
     });
+
+    // Retry once on unauthorized to support BotID cookie challenge flows
+    if (response.status === 401) {
+      response = await fetch(api, requestInit).catch(err => {
+        throw err;
+      });
+    }
 
     if (onResponse) {
       try {


### PR DESCRIPTION
## Background

Vercel BotID protection often requires a client-side challenge where the initial request receives a 401 to set necessary cookies/headers. The existing client-side fetch utilities in `useAssistant`, `callChatApi`, and `callCompletionApi` did not automatically retry after this initial 401, leading to persistent unauthorized errors for protected routes.

## Summary

This PR introduces a one-shot retry mechanism for 401 (Unauthorized) responses in the client-side fetch utilities: `packages/react/src/use-assistant.ts`, `packages/ui-utils/src/call-chat-api.ts`, and `packages/ui-utils/src/call-completion-api.ts`. This allows the client to automatically retry the request after the initial 401, ensuring that BotID-related cookies/headers set by the server are included in the subsequent attempt.

## Tasks

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If required, a _patch_ changeset for relevant packages has been added
- [ ] You've run `pnpm prettier-fix` to fix any formatting issues

## Future Work

- Users still need to ensure `credentials: 'include'` is passed to hooks for cross-origin API calls and that the server's CORS configuration allows credentials.
- Client-side BotID initialization (e.g., in `instrumentation.client.ts` or `<head>`) must still be correctly configured with matching protected routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad7cd0a5-48f1-41f0-b6f9-099c7f69a602">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad7cd0a5-48f1-41f0-b6f9-099c7f69a602">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

